### PR TITLE
Move to USD pricing and reduce to 15 GBP / mo for personal

### DIFF
--- a/_includes/banner2.html
+++ b/_includes/banner2.html
@@ -3,10 +3,10 @@
         <div class="pr-16 sm:text-center sm:px-16">
                 <p class="font-medium text-white">
                     <span class="md:hidden">
-                        Celebrate our launch! 20% off through August.
+                        Celebrate our launch with a discount!
                     </span>
                     <span class="hidden md:inline">
-                      To celebrate our launch, we’re offering a 20% discount on all software licenses through August, added at checkout.
+                      To celebrate our launch, we’re offering 20% off commercial licenses at checkout.
                     </span>
                 </p>
             </div>

--- a/_includes/faq.html
+++ b/_includes/faq.html
@@ -20,12 +20,13 @@
                 <div>
                     {% include faq/section.html heading="Can I try before I buy?" text="Yes, you can request a free 14-day trial <a class=\"underline inlets-blue-900\" href=\"https://docs.google.com/forms/d/e/1FAIpQLScfNQr1o_Ctu_6vbMoTJ0xwZKZ3Hszu9C-8GJGWw1Fnebzz-g/viewform?usp=sf_link\">here</a>" %}
                     {% include faq/section.html heading="How does the licensing work?" text="You purchase a license code which will be delivered as a JWT token, when it expires the software will stop working, so you should renew your license and update your key when that time approaches. The license is part of the client, so you do not have to re-create your servers." %}
-                    {% include faq/section.html heading="What is a tunnel-pair?" text="A tunnel-pair is an inlets PRO client and server. You need both to create a functioning tunnel." %}
-                    {% include faq/section.html heading="What if we need custom development, support or a proof of concept?" text="This is available at a further cost" %}
+                    {% include faq/section.html heading="What is a tunnel-pair?" text="A tunnel-pair is an inlets PRO client and server. You need both to create a functioning tunnel. inlets PRO can be self-hosted." %}
+                    {% include faq/section.html heading="What if we need custom development, support or a proof of concept?" text="This is available at a further cost, please contact sales for details." %}
+                    {% include faq/section.html heading="How do I pay for inlets PRO?" text="Prices are in USD for international customers, but charged in GBP. You can pay via PayPal or Stripe using the OpenFaaS Ltd Store. Enterprise customers can pay via invoice and bank transfer." %}
                 </div>
                 <div class="mt-12 md:mt-0">
                     {% include faq/section.html heading="Do I have to expose my applications on the Internet?" text="No, inlets PRO can bind to a private or local ethernet adapter, so that only the control-plane is available publicly over a secure websocket." %}
-                    {% include faq/section.html heading="Can I pay for inlets PRO monthly?" text="Inlets PRO licenses have a 12 month duration for business use, and 6 or 12-months for personal use." %}
+                    {% include faq/section.html heading="Can I pay for inlets PRO monthly?" text="Inlets PRO licenses have a 12 month duration for non-commercial and for business use." %}
                     {% include faq/section.html heading="What if I want to add more tunnel pairs during a period?" text="You can pay pro-rata to add more tunnels to your package." %}
                     {% include faq/section.html heading="Where can I use inlets PRO?" text="Inlets PRO can be used in any network because the client makes an outbound connection first to establish its link. This includes: NAT, Carrier Grade NAT (CGN), VPCs, containers, Kubernetes and even hotel WiFi. If you want to test your network conditions, just take out a free 14-day trial at any time." %}
                     {% include faq/section.html heading="Does inlets PRO \"call home\"?" text="We trust our users to purchase the correct license for their usage, and in return we make licensing simple with a fixed-term license." %}

--- a/_includes/pricing.html
+++ b/_includes/pricing.html
@@ -28,13 +28,13 @@
                                         <div class="mt-4 flex items-center justify-center">
                       <span class="px-3 flex items-start text-6xl leading-none tracking-tight text-blue-900">
                         <span class="mt-2 mr-2 text-4xl font-medium">
-                          £
+                          $
                         </span>
                         <span class="font-extrabold">
                           20*
                         </span>
                       </span>
-                                            <span class="text-xl leading-7 font-medium text-gray-500">
+                     <span class="text-xl leading-7 font-medium text-gray-500">
                         /month
                       </span>
                                         </div>
@@ -42,10 +42,10 @@
                                 </div>
                                 <div class="flex-1 flex flex-col justify-between border-t-2 border-gray-100 p-6 bg-gray-50 sm:p-10 lg:p-6 xl:p-10">
                                     <ul>
-                                        {% include pricing/feature.html feature="Unlimited tunnels for personal use" %}
-                                        {% include pricing/feature.html feature="Works with HTTP or TCP traffic" %}
-                                        {% include pricing/feature.html feature="Community Support" %}
+                                        {% include pricing/feature.html feature="Non-commercial use only" %}
+                                        {% include pricing/feature.html feature="Tunnel TCP and HTTP" %}
                                         {% include pricing/feature.html feature="Access to dozens of tutorials and complementary OSS projects" %}
+                                        {% include pricing/feature.html feature="Community Support" %}
                                     </ul>
                                     <div class="mt-8">
                                         <div class="rounded-lg shadow-md">
@@ -74,33 +74,33 @@
                                         Professional
                                     </h3>
                                     <div class="mt-4 flex items-center justify-center">
-                    <span class="px-3 flex items-start text-6xl leading-none tracking-tight text-blue-900 sm:text-6xl">
+                        <span class="px-3 flex items-start text-6xl leading-none tracking-tight text-blue-900 sm:text-6xl">
 
-                                                                <span class="text-2xl leading-8 font-medium text-gray-500 px-2">
-                      from
-                    </span>
-                      <span class="mt-2 mr-2 text-4xl font-medium">
-                       £
-                      </span>
-                      <span class="font-extrabold">
-                        100*
-                      </span>
-                    </span>
-                                        <span class="text-2xl leading-8 font-medium text-gray-500">
-                      /month
-                    </span>
+                        <span class="text-2xl leading-8 font-medium text-gray-500 px-2">
+                        from
+                        </span>
+                        <span class="mt-2 mr-2 text-4xl font-medium">
+                        $
+                        </span>
+                        <span class="font-extrabold">
+                            130*
+                        </span>
+                        </span>
+                        <span class="text-2xl leading-8 font-medium text-gray-500">
+                        /month
+                        </span>
                                     </div>
                                 </div>
                             </div>
                             <div class="border-t-2 border-gray-100 rounded-b-lg pt-10 pb-8 px-6 bg-gray-50 sm:px-10 sm:py-10">
                                 <ul>
-                                    {% include pricing/feature.html feature="Includes 5 tunnels" %}
                                     {% include pricing/feature.html feature="Licensed for commercial use" %}
-                                    {% include pricing/feature.html feature="Integrates directly with Kubernetes services" %}
-                                    {% include pricing/feature.html feature="Each additional tunnel - £20 / month" %}
+                                    {% include pricing/feature.html feature="Includes 4 pre-paid tunnels" %}
+                                    {% include pricing/feature.html feature="Each additional tunnel - $25 / month" %}
+                                    {% include pricing/feature.html feature="You keep control of your data" %}
+                                    {% include pricing/feature.html feature="Integrates directly with Kubernetes" %}
                                     {% include pricing/feature.html feature="Expand your public IP range" %}
-                                    {% include pricing/feature.html feature="Keep control of your data" %}
-                                    {% include pricing/feature.html feature="Community support" %}
+                                    {% include pricing/feature.html feature="Email support" %}
                                 </ul>
                                 <div class="mt-10">
                                     <div class="rounded-lg shadow-md">
@@ -121,20 +121,22 @@
                                             Enterprise
                                         </h3>
                                         <div class="mt-4 flex items-center justify-center">
-                      <span class="px-3 flex items-start text-6xl leading-none tracking-tight text-blue-900">
-                        <span class="mt-2 mr-2 text-4xl font-medium">
-                          Contact us
-                        </span>
-                      </span>
+                                            <span class="px-3 flex items-start text-6xl leading-none tracking-tight text-blue-900">
+                                                <span class="mt-2 mr-2 text-4xl font-medium">
+                                                Contact us
+                                                </span>
+                                            </span>
                                         </div>
                                     </div>
                                 </div>
                                 <div class="flex-1 flex flex-col justify-between border-t-2 border-gray-100 p-6 bg-gray-50 sm:p-10 lg:p-6 xl:p-10">
                                     <ul>
-                                        {% include pricing/feature.html feature="Email support" %}
-                                        {% include pricing/feature.html feature="Bulk pricing" %}
+                                        {% include pricing/feature.html feature="Licensed for use within a product" %}
+                                        {% include pricing/feature.html feature="Bulk discounts" %}
                                         {% include pricing/feature.html feature="Management add-on" %}
-                                        {% include pricing/feature.html feature="Proof of concept (upon request)" %}
+                                        {% include pricing/feature.html feature="Implementation (upon request)" %}
+                                        {% include pricing/feature.html feature="Custom development (upon request)" %}
+                                        {% include pricing/feature.html feature="Priority email support" %}
                                     </ul>
                                     <div class="mt-8">
                                         <div class="rounded-lg shadow-md">

--- a/docs/index.html
+++ b/docs/index.html
@@ -272,7 +272,7 @@
         </svg>
     </div>
     <p class="ml-3 text-base leading-6 font-medium text-gray-500">
-        Includes 5 tunnels
+        Includes 4 tunnels
     </p>
 </li>
                                     <li class="mt-4 flex items-start">

--- a/index.html
+++ b/index.html
@@ -17,7 +17,3 @@ layout: default
 {% include faq.html %}
 {% include cta.html %}
 <div style="padding-bottom: 20px;"></div>
-
-
-
-


### PR DESCRIPTION
Makes personal use more affordable and attractive
Lists in USD for international buyers
Makes business tier easier to enter, and has 4 tunnels instead
of 5.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>