### PR TITLE
Add minificaiton of css with purgecss

### DIFF
--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  enabled: true,
   content: ["./_site/**/*.html"],
   css: ["./_site/css/site.css"],
   defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []


### PR DESCRIPTION
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

# Now
![image](https://user-images.githubusercontent.com/40488132/112711709-5709ed00-8ec2-11eb-84cb-19129e275ecb.png)


# Then (old on inlets.dev live) 
![image](https://user-images.githubusercontent.com/40488132/112711750-b36d0c80-8ec2-11eb-8a14-b12459a5a94b.png)


I think the first column in mine isnt using gzip, whereas its being used for inlets.dev. The second column is the "total" size, as you can see they are significantly smaller. 

