### PR TITLE
Rename helm charts in blog posts

### DIFF
--- a/blog/_posts/2020-11-16-inlets-the-ipv6-proxy.md
+++ b/blog/_posts/2020-11-16-inlets-the-ipv6-proxy.md
@@ -135,7 +135,7 @@ Connect your inlets client:
 
 ```bash
 export UPSTREAM=http://127.0.0.1:8080
-inlets client --remote "ws://147.75.33.3:8080" \
+inlets tcp client --remote "ws://147.75.33.3:8080" \
     --token "CnLgAxPkOw594ZbZ0nEfsbclpQUov9ZBFKLOyx559efgzdITeAhgCHtaH74zysHZ" \
     --upstream $UPSTREAM
 ```

--- a/blog/_posts/2020-12-15-multi-cluster-monitoring.md
+++ b/blog/_posts/2020-12-15-multi-cluster-monitoring.md
@@ -156,13 +156,14 @@ dataPlane:
 Now get the inlets-pro helm chart and install the chart for each remote Prometheus service.
 
 ```bash
-git clone https://github.com/inlets/inlets-pro
+$ helm repo add inlets-pro https://inlets.github.io/inlets-pro/charts/
+$ helm repo update
 
-helm install orion-aws      ./inlets-pro/chart/inlets-pro \
+helm install orion-aws inlets-pro/inlets-tcp-server \
    -n monitoring -f custom.yaml \
    --set ingress.domain=orion-aws.prometheus.example.com
 
-helm install orion-equinix  ./inlets-pro/chart/inlets-pro \
+helm install orion-equinix inlets-pro/inlets-tcp-server \
   -n monitoring -f custom.yaml \
   --set ingress.domain=orion-equinix.prometheus.example.com
 ```
@@ -201,11 +202,11 @@ kubectl create secret generic \
   --from-file token=./token.txt
 ```
 
-And install the inlets-pro-client chart with the proper values to connect to the exit-node pods in the Observability cluster:
+And install the inlets-tcp-client chart with the proper values to connect to the exit-node pods in the Observability cluster:
 
 ```bash
 helm install prometheus-tunnel \
-  ./inlets-pro/chart/inlets-pro-client \
+  inlets-pro/inlets-tcp-client \
   -n monitoring \
   --set url=wss://orion-aws2.prometheus.sphene.io/connect \
   --set upstream=prometheus \

--- a/blog/_posts/2021-03-15-scaling-inlets.md
+++ b/blog/_posts/2021-03-15-scaling-inlets.md
@@ -153,12 +153,13 @@ Let's say the first tunnel we would like to create is for making our on premise 
 Get the inlets-pro helm chart, generate a token for the inlets server and install the chart for the Keycload service:
 
 ```bash
-git clone https://github.com/inlets/inlets-pro
+helm repo add inlets-pro https://inlets.github.io/inlets-pro/charts/
+helm repo update
 
 kubectl create secret generic inlets-keycloak-token \
   --from-literal token=$(head -c 16 /dev/random | shasum|cut -d" " -f1)
 
-helm upgrade --install keycloak ./inlets-pro/chart/inlets-pro \
+helm upgrade --install keycloak inlets-pro/inlets-tcp-server \
   --set tokenSecretName=inlets-keycloak-token \
   --set ingress.annotations=null \
   --set ingress.secretName=inlets-tls \
@@ -193,7 +194,7 @@ PORT=$2
 kubectl create secret generic inlets-$NAME-token \
   --from-literal token=$(head -c 16 /dev/random | shasum|cut -d" " -f1)
 
-helm upgrade --install $NAME ./inlets-pro/chart/inlets-pro \
+helm upgrade --install $NAME inlets-pro/inlets-tcp-server \
   --set tokenSecretName=inlets-$NAME-token \
   --set ingress.annotations=null \
   --set ingress.secretName=inlets-tls \

--- a/blog/_posts/2021-07-08-short-lived-clusters.md
+++ b/blog/_posts/2021-07-08-short-lived-clusters.md
@@ -172,8 +172,8 @@ kubectl create secret generic -n default \
 ```
 
 ```bash
-git clone https://github.com/inlets/inlets-pro
-cd inlets-pro/chart/inlets-pro-client
+$ helm repo add inlets-pro https://inlets.github.io/inlets-pro/charts/
+$ helm repo update
 
 helm upgrade --install \
   --namespace default \
@@ -184,7 +184,7 @@ helm upgrade --install \
   --set tokenSecretName=nginx-1-tunnel-token \
   --set fullnameOverride="nginx-1-tunnel" \
   nginx-1-tunnel \
-  ./
+  inlets-pro/inlets-pro-client
 ```
 
 The key fields you need to set are:
@@ -240,11 +240,11 @@ kubectl create secret generic -n default \
   --from-literal token=DP4bepIxuNXbjbtXWsu6aSkEE9r5cvMta56le2ajP7l9ajJpAgEcFxBTWSlR2PdB
 ```
 
-Just follow the steps from before, then change the helm install to the following:
+Just follow the steps from before, then change the `helm install` to the following:
 
 ```bash
-git clone https://github.com/inlets/inlets-pro
-cd inlets-pro/chart/inlets-pro-client
+helm repo add inlets-pro https://inlets.github.io/inlets-pro/charts/
+helm repo update
 
 helm upgrade --install \
   --namespace kube-system \
@@ -255,7 +255,7 @@ helm upgrade --install \
   --set tokenSecretName=traefik-tunnel-token \
   --set fullnameOverride="traefik-tunnel" \
   traefik-tunnel \
-  ./
+  inlets-pro/inlets-tcp-client
 ```
 
 What changed?

--- a/blog/_posts/2021-07-22-riskfuel.md
+++ b/blog/_posts/2021-07-22-riskfuel.md
@@ -116,8 +116,8 @@ kubectl create secret generic -n default \
 
 Next, we can quickly deploy the client using the helm chart:
 ```bash
-git clone https://github.com/inlets/inlets-pro
-cd inlets-pro/chart/inlets-pro-client
+helm repo add inlets-pro https://inlets.github.io/inlets-pro/charts/
+helm repo update
 
 helm install \
   --namespace default \
@@ -127,7 +127,7 @@ helm install \
   --set url=wss://<inlets-server-ip>:<control-port> \
   --set fullnameOverride="inlets-client" \
     inlets-client \
-    ./ 
+    ./inlets-tcp-client
 ```
 
 Now, provided our Kubernetes API server is configured to allow incoming requests to come in via `<inlets-server-ip>`, we can run kubectl commands as if this were any other cluster in our kubeconfig. 

--- a/blog/_posts/2022-08-03-accessing-customer-services.md
+++ b/blog/_posts/2022-08-03-accessing-customer-services.md
@@ -179,7 +179,7 @@ Install the inlets-pro TCP server using its helm chart:
 export DOMAIN="postgresql-customer1.example.com"
 
 helm upgrade --install postgresql-customer1-tunnel \
-  inlets-pro/inlets-pro \
+  inlets-pro/inlets-tcp-server \
   --set ingress.domain=$DOMAIN \
   -f ./values-postgresql-customer1.yaml
 ```
@@ -276,7 +276,7 @@ Then install the tunnel server with Helm:
 export DOMAIN="mysql-customer2.example.com"
 
 helm upgrade --install mysql-customer2-tunnel \
-  inlets-pro/inlets-pro \
+  inlets-pro/inlets-tcp-server \
   --set ingress.domain=$DOMAIN \
   -f ./values-mysql-customer2.yaml
 ```


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

Rename helm charts in blog posts:

inlets-tcp-server/client
inlets-http-server

@jsiebens could you update any of your own blog posts please? And the arkade app you contributed for us?

cc @welteki 