### PR TITLE
Add tunnel auth feature to pricing grid

### DIFF
--- a/_includes/pricing/pricing-grid.html
+++ b/_includes/pricing/pricing-grid.html
@@ -96,6 +96,13 @@
           </tr>
 
           <tr class="border-t border-gray-200">
+            <th class="py-5 px-4 text-sm font-normal text-gray-500 text-left" scope="row">OAuth for HTTP tunnels</th>
+            <td class="py-5 pr-4">
+              <span class="block text-sm text-gray-700 text-right">GitHub (username, email)</span>
+            </td>
+          </tr>
+
+          <tr class="border-t border-gray-200">
             <th class="py-5 px-4 text-sm font-normal text-gray-500 text-left" scope="row">Kubernetes Integration.</th>
             <td class="py-5 pr-4">
               <!-- Heroicon name: check -->
@@ -283,6 +290,12 @@
             </td>
           </tr>
 
+          <tr class="border-t border-gray-200">
+            <th class="py-5 px-4 text-sm font-normal text-gray-500 text-left" scope="row">OAuth for HTTP tunnels</th>
+            <td class="py-5 pr-4">
+              <span class="block text-sm text-gray-700 text-right">Google or GitHub (username, email, organisation)</span>
+            </td>
+          </tr>
 
           <tr class="border-t border-gray-200">
             <th class="py-5 px-4 text-sm font-normal text-gray-500 text-left" scope="row">Commercial use.</th>
@@ -463,6 +476,13 @@
                 <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
               </svg>
               <span class="sr-only">Yes</span>
+            </td>
+          </tr>
+
+          <tr class="border-t border-gray-200">
+            <th class="py-5 px-4 text-sm font-normal text-gray-500 text-left" scope="row">OAuth for HTTP tunnels</th>
+            <td class="py-5 pr-4">
+              <span class="block text-sm text-gray-400 text-right">n/a</span>
             </td>
           </tr>
 
@@ -792,6 +812,19 @@
                 <path fill-rule="evenodd" d="M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd" />
               </svg>
               <span class="sr-only">Not in Uplink</span>
+            </td>
+          </tr>
+
+          <tr>
+            <th class="py-5 px-6 text-sm font-normal text-gray-500 text-left" scope="row">OAuth for HTTP tunnels</th>
+            <td class="py-5 px-6">
+              <span class="block text-sm text-gray-700">GitHub (username, email)</span>
+            </td>
+            <td class="py-5 px-6">
+              <span class="block text-sm text-gray-700">Google or GitHub (username, email or organisation)</span>
+            </td>
+            <td class="py-5 px-6">
+              <span class="block text-sm text-gray-400">n/a</span>
             </td>
           </tr>
 


### PR DESCRIPTION
## Description

Add OAuth for http tunnels to the feature grid on the pricing page.

![Screenshot 2025-03-12 at 16 01 59](https://github.com/user-attachments/assets/d48b6c3c-eee2-4128-9e6c-16645bd2cf19)
