### PR TITLE
Remove deprecated --letsencrypt-email flag from documentation

### DIFF
--- a/blog/_posts/2021-02-11-secure-letsencrypt-tunnel.md
+++ b/blog/_posts/2021-02-11-secure-letsencrypt-tunnel.md
@@ -68,7 +68,6 @@ export DOMAIN="alexellis.inlets.dev"
 
 inlets-pro http server \
   --letsencrypt-domain $DOMAIN \
-  --letsencrypt-email webmaster@$DOMAIN \
   --letsencrypt-issuer prod \
   --token $TOKEN \
   --auto-tls \
@@ -78,7 +77,6 @@ inlets-pro http server \
 Here's what each flag does:
 
 * `--letsencrypt-domain` - gets a TLS cert for each domain given, you can provide this flag multiple times
-* `--letsencrypt-email` - required for renewal notifications and for accepting the Let's Encrypt Terms of Service
 * `--letsencrypt-issuer` - use the value `prod` or `staging` to switch between the two options
 
 The `--token` is used by the inlets client to authenticate to the server.
@@ -90,7 +88,6 @@ You can keep the inlets server process running by generating a systemd unit file
 ```bash
 inlets-pro http server \
   --letsencrypt-domain $DOMAIN \
-  --letsencrypt-email webmaster@$DOMAIN \
   --letsencrypt-issuer prod \
   --token $TOKEN \
   --auto-tls \

--- a/blog/_posts/2021-04-13-your-isp-wont-give-you-a-static-ip.md
+++ b/blog/_posts/2021-04-13-your-isp-wont-give-you-a-static-ip.md
@@ -79,7 +79,6 @@ export DOMAIN=tunnel.example.com
 
 inletsctl create \
   --letsencrypt-domain $DOMAIN \
-  --letsencrypt-email contact@$DOMAIN \
   --letsencrypt-issuer prod \
   --provider digitalocean \
   --region lon1 \

--- a/blog/_posts/2021-08-08-private-tunnel.md
+++ b/blog/_posts/2021-08-08-private-tunnel.md
@@ -45,8 +45,7 @@ inletsctl create \
  --region lon1 \
  --provider digitalocean \
  --access-token-file ~/digital-ocean-api-key.txt \
- --letsencrypt-domain blog.example.com \
- --letsencrypt-email webmaster@example.com
+ --letsencrypt-domain blog.example.com
 ```
 
 A VM will be created in your account using the cheapest plan available, for DigitalOcean this costs 5 USD / mo at time of writing.
@@ -83,8 +82,7 @@ You can pass a number of sub-domains, for instance:
 
 ```bash
  --letsencrypt-domain blog.example.com \
- --letsencrypt-domain grafana.example.com \
- --letsencrypt-email webmaster@example.com
+ --letsencrypt-domain grafana.example.com
 ```
 
 ## Connect your tunnel client

--- a/blog/_posts/2021-09-09-compose-and-inlets.md
+++ b/blog/_posts/2021-09-09-compose-and-inlets.md
@@ -78,7 +78,6 @@ inletsctl create \
   --provider linode \
   --region us-east \
   --access-token-file $HOME/linode-key.txt \
-  --letsencrypt-email webmaster@$DOMAIN \
   --letsencrypt-domain $DOMAIN
 ```
 

--- a/blog/_posts/2022-09-02-monitor-inlets-with-grafana.md
+++ b/blog/_posts/2022-09-02-monitor-inlets-with-grafana.md
@@ -34,8 +34,7 @@ inletsctl create \
     --region fra1 \
     --provider digitalocean \
     --access-token-file ~/.do/access-token \
-    --letsencrypt-domain app.example.com \
-    --letsencrypt-email webmaster@example.com
+    --letsencrypt-domain app.example.com
 ```
 
 This command will create a VM in your DigitalOcean account. Once the tunnel server has been created it will print out: the ip address, the inlets token and the endpoint for inlets client to connect to.

--- a/blog/_posts/2022-11-17-automate-a-self-hosted-https-tunnel.md
+++ b/blog/_posts/2022-11-17-automate-a-self-hosted-https-tunnel.md
@@ -50,7 +50,6 @@ By using our open source [inletsctl](https://github.com/inlets/inletsctl) tool, 
 inletsctl create --provider digitalocean \
   --region lon1 \
   --letsencrypt-domain blog.example.com \
-  --letsencrypt-email webmaster@example.com \
   --access-token-file ~/do-token
 ```
 

--- a/blog/_posts/2023-01-17-expose-multiple-services-with-inlets-and-caddy.md
+++ b/blog/_posts/2023-01-17-expose-multiple-services-with-inlets-and-caddy.md
@@ -105,10 +105,6 @@ Both records should point to the IP address of the server you created in the ear
 Next create the caddy configuration file `/etc/caddy/Caddyfile`:
 
 ```
-{
-    email email@inlets.example.com
-}
-
 inlets.example.com {
     reverse_proxy localhost:8123
 }
@@ -121,11 +117,11 @@ inlets.example.com {
 }
 ```
 
-We define three blocks in the caddy configuration file. The first block on the top of the file can be used to define the email to use for the renewal notifications on the domains.
+We define two blocks in the caddy configuration file.
 
-In the second we configure caddy to reverse proxy the control-plane for the tunnel server using the domain `inlets.example.com`. Caddy will automatically obtain a valid TLS certificate for this domain.
+In the first block we configure caddy to reverse proxy the control-plane for the tunnel server using the domain `inlets.example.com`. Caddy will automatically obtain a valid TLS certificate for this domain.
 
-In the third block we configure a wildcard domain `*.inlets.example.com` and point it to the data-plane of the tunnel. To generate a wildcard certificate you will need to use the DNS-01 challenge type which requires using a supported DNS provider. This is defined with a `tls { }` block added below the domain definition. The configuration might be different depending on you DNS provider. You can find the specific configuration info and instructions to configure authentication for your provider in the [repo of you DNS provider plugin](https://github.com/orgs/caddy-dns/repositories?type=all).
+In the second block we configure a wildcard domain `*.inlets.example.com` and point it to the data-plane of the tunnel. To generate a wildcard certificate you will need to use the DNS-01 challenge type which requires using a supported DNS provider. This is defined with a `tls { }` block added below the domain definition. The configuration might be different depending on you DNS provider. You can find the specific configuration info and instructions to configure authentication for your provider in the [repo of you DNS provider plugin](https://github.com/orgs/caddy-dns/repositories?type=all).
 
 Make sure to move the caddy binary you downloaded or compiled with xcaddy into your path:
 

--- a/blog/_posts/2023-08-23-keycloak-tls.md
+++ b/blog/_posts/2023-08-23-keycloak-tls.md
@@ -59,8 +59,7 @@ inletsctl create \
     --region lon1 \
     --access-token-file $HOME/.config/doctl/access-token \
     --tunnel-name keycloak \
-    --letsencrypt-domain $DOMAIN \
-    --letsencrypt-email webmaster@$DOMAIN
+    --letsencrypt-domain $DOMAIN
 ```
 
 I used an access token from DigitalOcean above, but you can also create tunnels on AWS, Azure, Google Cloud, Linode and others, just see the reference guide for how to create an access token for each.

--- a/blog/_posts/2023-08-31-tunnel-aws-ec2.md
+++ b/blog/_posts/2023-08-31-tunnel-aws-ec2.md
@@ -69,8 +69,7 @@ inletsctl create \
   --access-token-file ~/.inlets/ec2-access-key \
   --region eu-west-1 \
   --aws-key-name inlets \
-  --letsencrypt-domain blog.example.com \
-  --letsencrypt-email webmaster@example.com
+  --letsencrypt-domain blog.example.com
 ```
 
 The region that you specify here, must match the region where you created your SSH Key Pair, otherwise it will not be found. The `--aws-key-name` flag is optional, but recommended.

--- a/blog/_posts/2024-06-06-tunnel-k8s-via-aws-ec2.md
+++ b/blog/_posts/2024-06-06-tunnel-k8s-via-aws-ec2.md
@@ -93,7 +93,6 @@ inlets-pro http server \
     --token-file `pwd`/token.txt \
     --letsencrypt-domain $DOMAIN1 \
     --letsencrypt-domain $DOMAIN2 \
-    --letsencrypt-email $EMAIL \
     --generate=systemd > inlets-server.service
 
 sudo mv inlets-server.service /etc/systemd/system/inlets-server.service

--- a/examples.md
+++ b/examples.md
@@ -38,7 +38,6 @@ HTTPS example
 # Setup a server in HTTPS mode
 $ inlets-pro http server --auto-tls --auto-tls-san "178.62.70.130" \
   --letsencrypt-domain "api.example.com" \
-  --letsencrypt-email "mail@example.com" \
   --token $AUTH
 
 # Connect a client and instruct the server which address to use 


### PR DESCRIPTION
## Description

Removes all references to the deprecated `--letsencrypt-email` flag from blog posts and examples.

## Motivation and context

The `--letsencrypt-email` flag has been removed from both the inlets http server and inletsctl, making these documentation references outdated and potentially confusing for users.