### PR TITLE
Add post on auto-TLS verification step and improve 404 style

### DIFF
--- a/404.md
+++ b/404.md
@@ -4,11 +4,8 @@ title: 404 - Destination Unreachable
 permalink: /404.html
 ---
 
-<div class="min-h-[70vh] flex flex-col items-center justify-center px-4 py-16 text-center bg-white relative overflow-hidden">
-  <!-- Subtle grid background -->
-  <div class="absolute inset-0 bg-[linear-gradient(to_right,#f3f4f6_1px,transparent_1px),linear-gradient(to_bottom,#f3f4f6_1px,transparent_1px)] bg-[size:2rem_2rem] opacity-60 pointer-events-none"></div>
-
-  <div class="relative z-10 max-w-2xl w-full">
+<div class="min-h-screen flex flex-col items-center justify-center px-4 py-16 text-center bg-white">
+  <div class="max-w-2xl w-full">
     <h1 class="text-8xl font-black tracking-tighter text-gray-900 mb-2">404</h1>
     <h2 class="text-2xl font-semibold text-gray-800 mb-4">Page not found</h2>
     <p class="text-gray-600 leading-relaxed max-w-md mx-auto mb-8">

--- a/404.md
+++ b/404.md
@@ -1,9 +1,41 @@
 ---
-layout: default
-title: 404 - Page not found
+layout: minimal
+title: 404 - Destination Unreachable
 permalink: /404.html
 ---
 
-Sorry, we can't find that page that you're looking for. You can try again by going [back to the homepage]({{ site.baseurl }}/).
+<div class="min-h-[70vh] flex flex-col items-center justify-center px-4 py-16 text-center bg-white relative overflow-hidden">
+  <!-- Subtle grid background -->
+  <div class="absolute inset-0 bg-[linear-gradient(to_right,#f3f4f6_1px,transparent_1px),linear-gradient(to_bottom,#f3f4f6_1px,transparent_1px)] bg-[size:2rem_2rem] opacity-60 pointer-events-none"></div>
 
-[<img src="{{ site.baseurl }}/images/404.jpg" alt="Constructocat by https://github.com/jasoncostello" style="width: 400px;"/>]({{ site.baseurl }}/)
+  <div class="relative z-10 max-w-2xl w-full">
+    <h1 class="text-8xl font-black tracking-tighter text-gray-900 mb-2">404</h1>
+    <h2 class="text-2xl font-semibold text-gray-800 mb-4">Page not found</h2>
+    <p class="text-gray-600 leading-relaxed max-w-md mx-auto mb-8">
+      The resource you're looking for doesn't exist, has been moved, or the tunnel was never established. Check the URL or navigate back to a known endpoint.
+    </p>
+
+    <div class="flex flex-col sm:flex-row gap-4 justify-center mb-10">
+      <a href="/" class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 transition duration-150 ease-in-out shadow-sm">
+        Return to homepage
+      </a>
+      <a href="https://docs.inlets.dev" class="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-base font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 transition duration-150 ease-in-out">
+        Open documentation
+      </a>
+    </div>
+
+    <div class="pt-6 border-t border-gray-200">
+      <p class="text-sm text-gray-500 mb-3">Quick navigation</p>
+      <div class="flex flex-wrap justify-center gap-6 text-sm text-gray-600">
+        <a href="/#top" class="hover:text-indigo-600 transition duration-150 ease-in-out">About</a>
+        <a href="/uplink/" class="hover:text-indigo-600 transition duration-150 ease-in-out">Uplink</a>
+        <a href="/cloud/" class="hover:text-indigo-600 transition duration-150 ease-in-out">Cloud</a>
+        <a href="/blog/" class="hover:text-indigo-600 transition duration-150 ease-in-out">Blog</a>
+        <a href="/pricing/" class="hover:text-indigo-600 transition duration-150 ease-in-out">Pricing</a>
+        <a href="https://docs.inlets.dev" class="hover:text-indigo-600 transition duration-150 ease-in-out">Docs</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,13 +2,14 @@
     <div class="max-w-screen-xl mx-auto py-12 px-4 sm:px-6 md:flex md:items-center md:justify-between lg:px-8">
         <div class="w-full md:hidden mb-8">
             <nav class="flex flex-wrap justify-center gap-x-6 gap-y-3 text-sm text-gray-500">
-                <a href="/pricing/" class="hover:text-gray-900 transition duration-150 ease-in-out">Pricing</a>
+                <a href="/#top" class="hover:text-gray-900 transition duration-150 ease-in-out">About</a>
+                <a href="/uplink/" class="hover:text-gray-900 transition duration-150 ease-in-out">Uplink</a>
+                <a href="/cloud/" class="hover:text-gray-900 transition duration-150 ease-in-out">Cloud</a>
                 <a href="/blog/" class="hover:text-gray-900 transition duration-150 ease-in-out">Blog</a>
-                <a href="/uplink/" class="hover:text-gray-900 transition duration-150 ease-in-out">Inlets Uplink</a>
-                <a href="/cloud/" class="hover:text-gray-900 transition duration-150 ease-in-out">Inlets Cloud</a>
+                <a href="/pricing/" class="hover:text-gray-900 transition duration-150 ease-in-out">Pricing</a>
+                <a href="https://docs.inlets.dev" class="hover:text-gray-900 transition duration-150 ease-in-out">Docs</a>
                 <a href="/contact" class="hover:text-gray-900 transition duration-150 ease-in-out">Contact</a>
                 <a href="/eula" class="hover:text-gray-900 transition duration-150 ease-in-out">EULA</a>
-                <a href="https://docs.inlets.dev" class="hover:text-gray-900 transition duration-150 ease-in-out">Docs</a>
             </nav>
         </div>
         <div class="flex justify-center md:order-3">
@@ -31,13 +32,14 @@
 
             </p>
             <nav class="hidden md:flex mt-4 flex-wrap justify-center gap-x-6 gap-y-3 text-sm text-gray-500">
-                <a href="/pricing/" class="hover:text-gray-900 transition duration-150 ease-in-out">Pricing</a>
+                <a href="/#top" class="hover:text-gray-900 transition duration-150 ease-in-out">About</a>
+                <a href="/uplink/" class="hover:text-gray-900 transition duration-150 ease-in-out">Uplink</a>
+                <a href="/cloud/" class="hover:text-gray-900 transition duration-150 ease-in-out">Cloud</a>
                 <a href="/blog/" class="hover:text-gray-900 transition duration-150 ease-in-out">Blog</a>
-                <a href="/uplink/" class="hover:text-gray-900 transition duration-150 ease-in-out">Inlets Uplink</a>
-                <a href="/cloud/" class="hover:text-gray-900 transition duration-150 ease-in-out">Inlets Cloud</a>
+                <a href="/pricing/" class="hover:text-gray-900 transition duration-150 ease-in-out">Pricing</a>
+                <a href="https://docs.inlets.dev" class="hover:text-gray-900 transition duration-150 ease-in-out">Docs</a>
                 <a href="/contact" class="hover:text-gray-900 transition duration-150 ease-in-out">Contact</a>
                 <a href="/eula" class="hover:text-gray-900 transition duration-150 ease-in-out">EULA</a>
-                <a href="https://docs.inlets.dev" class="hover:text-gray-900 transition duration-150 ease-in-out">Docs</a>
             </nav>
         </div>
         <div class="mt-8 md:mt-0 md:order-1 flex justify-center">

--- a/_layouts/minimal.html
+++ b/_layouts/minimal.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{% if page.title %}{{ page.title }} – {% endif %}{{ site.name }}</title>
+    {% include meta.html %}
+    <link rel="icon" type="image/svg+xml" href="/images/inlets-icon.svg" />
+    <link rel="stylesheet" href="/css/site.css?v={{ site.time | date: '%s' }}">
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
+    <style>
+      body { margin: 0; font-family: 'Inter', ui-sans-serif, system-ui, sans-serif; }
+    </style>
+  </head>
+  <body>
+    <div class="flex items-center justify-center py-6">
+      <a href="/" aria-label="inlets home">
+        <img style="height: 48px; width: auto" alt="inlets" src="/images/logo.svg">
+      </a>
+    </div>
+    {{ content }}
+    <footer class="mt-16 pt-8 border-t border-gray-200 text-center">
+      <p class="text-sm text-gray-400">
+        Inlets&reg; is a trademark of OpenFaaS Ltd. All rights reserved, registered company in the UK: 11076587
+      </p>
+    </footer>
+  </body>
+</html>

--- a/blog/_posts/2026-07-13-hardening-auto-tls.md
+++ b/blog/_posts/2026-07-13-hardening-auto-tls.md
@@ -18,11 +18,31 @@ Practically speaking, the current version could be subject to a complex man-in-t
 
 As of inlets-pro 0.11.14, we've added belt and braces against MITM vectors: the client now verifies the CA belongs to the server it's connecting to, using the tunnel's token for an extra layer of hardening.
 
+```
+┌──────────┐              ┌──────────┐
+│  Client  │─────────────▶│  Server  │
+│          │◀─── CA ──────│          │
+│ trust    │              │          │
+└──────────┘              └──────────┘
+  Before: Client trusts any CA it receives.
+
+┌──────────┐              ┌──────────┐
+│  Client  │─────────────▶│  Server  │
+│          │  nonce       │          │
+│          │─────────────▶│          │
+│          │              │    CA    │
+│          │◀─────────────│◀── HMAC  │
+│          │  CA + proof  │          │
+│ verify   │              │          │
+└──────────┘              └──────────┘
+  After: Client verifies CA before trusting.
+```
+
 ## How it works
 
 The client and server already share a token. We've now added a step where the client verifies the CA using that token.
 
-The client generates a random value and sends it to the server. The server signs it along with the CA using the shared token. The client checks the signature. If it matches, the CA is trusted.
+The client generates a random value and sends it to the server. The server computes an HMAC over it and the CA using the shared token. The client checks the result. If it matches, the CA is trusted.
 
 The random value means an old CA from a previous server run can't be reused. And the token is never sent in plaintext during this exchange.
 

--- a/blog/_posts/2026-07-13-hardening-auto-tls.md
+++ b/blog/_posts/2026-07-13-hardening-auto-tls.md
@@ -1,0 +1,99 @@
+---
+layout: post
+title: "Hardening Auto-TLS for Inlets Tunnels"
+description: "inlets-pro 0.11.14 adds a verification step to auto-TLS, hardening the first-connection trust model against MITM vectors."
+author: Alex Ellis
+tags: security tls inlets-pro auto-tls
+category: release
+rollup: true
+author_img: alex
+date: 2026-07-13
+---
+
+When you SSH to a server for the first time, you get a prompt asking you to verify the host fingerprint. Most people just hit "yes" and move on. We know we should check the fingerprint, but in practice, individuals rarely collect server fingerprints and add them manually to their `known_hosts` file.
+
+The `--auto-tls` feature for HTTP and TCP tunnels takes a very similar approach. On first connection, the client fetches the server's self-signed CA and trusts it without verification.
+
+Practically speaking, the current version could be subject to a complex man-in-the-middle attack on first connection. An attacker would need to sit on the network between your client and server, intercept the initial handshake, and serve their own CA before the real one. This would require physical access to the network or ISP-level interception. It's unlikely to affect most users in day-to-day operation, but we wanted to harden the product regardless.
+
+As of inlets-pro 0.11.14, we've added belt and braces against MITM vectors: the client now verifies the CA belongs to the server it's connecting to, using the tunnel's token for an extra layer of hardening.
+
+## How it works
+
+The client and server already share a token. We've now added a step where the client verifies the CA using that token.
+
+The client generates a random value and sends it to the server. The server signs it along with the CA using the shared token. The client checks the signature. If it matches, the CA is trusted.
+
+The random value means an old CA from a previous server run can't be reused. And the token is never sent in plaintext during this exchange.
+
+## Which products are affected?
+
+This change only applies to inlets-pro HTTP and TCP tunnels that use `--auto-tls`. If you're not using auto-TLS, nothing changes.
+
+Here's the full picture:
+
+- **inlets-pro HTTP tunnels with auto-TLS** — verification is now enabled
+- **inlets-pro TCP tunnels with auto-TLS** — verification is now enabled
+- **inlets-pro HTTP or TCP tunnels with custom TLS** — not affected, you provide your own certificate
+- **inlets uplink** — not affected, does not implement auto-TLS and relies on Let's Encrypt or vendor certificates already in the trust bundle
+- **inlets-pro status** — verification is now enabled when using auto-TLS, with `--auto-tls-legacy` to talk to older servers
+
+## Upgrading
+
+The easiest path is to delete your existing tunnel server and recreate it. Most tunnel servers are created by [inletsctl](https://github.com/inlets/inletsctl), so you can simply delete and recreate:
+
+```bash
+inletsctl delete
+inletsctl create
+```
+
+Make sure to add back any flags you used previously — `--letsencrypt-domain`, `--tcp`, `--provider`, or any others. This gives you a fresh server running 0.11.14, a new token, and a new IP address.
+
+Before you delete the old server, set the TTL on any DNS A or CNAME records pointing at it to something low like 60 seconds. That way when you update the record to the new IP after recreating, the change will propagate quickly.
+
+If you're using the [inlets-operator](https://github.com/inlets/inlets-operator) on Kubernetes, upgrade the operator via the Helm chart first, then delete any existing tunnels so they're recreated with the new version:
+
+```bash
+helm upgrade inlets-operator inlets/inlets-operator \
+  --set image.tag=0.11.14
+
+kubectl delete tunnelserver <name>
+```
+
+The operator will recreate the tunnel server automatically. If you have DNS records pointing at the server, set the TTL to 60 seconds before deleting the tunnel, then update the record to the new IP once it's recreated.
+
+If you prefer to do a rolling upgrade in place, you can use `--auto-tls-legacy` as a temporary bridge. A new client connecting to an older server will fail, so add the flag to the client:
+
+```bash
+inlets-pro tcp client \
+  --url wss://server.example.com:8123 \
+  --token AUTH_TOKEN \
+  --auto-tls-legacy \
+  --upstream 127.0.0.1 \
+  --ports 80,443
+```
+
+This restores the previous behaviour and prints a warning. On the server, `--auto-tls-legacy` allows older clients to continue fetching the CA without verification. Remove the flag from both sides once everything is upgraded. The `inlets-pro status` command also supports `--auto-tls-legacy` if you need to query an older server.
+
+## Empty tokens no longer accepted
+
+If you're running auto-TLS, the server now requires a non-empty token. Previously an empty token was accepted, which meant any client could connect without authentication. If you were running without a token, the server will now refuse to start.
+
+#### Token strength
+
+The security of this feature depends on your token being strong. Use at least 32 bytes of random data:
+
+```bash
+openssl rand -base64 32 > ./token
+```
+
+## Wrapping up
+
+Auto-TLS now verifies the server identity, not just encrypts the connection. The trust anchor is the shared token, which you already control. No extra configuration needed once you're on the updated client and server.
+
+If you're already using a token with auto-TLS, the feature is enabled automatically on upgrade.
+
+* [Read the 0.11.14 release notes](https://github.com/inlets/inlets-pro/releases/tag/0.11.14)
+* [Docs: Automated HTTP tunnel server](https://docs.inlets.dev/tutorial/automated-http-server/)
+* [Docs: Automated TCP tunnel server](https://docs.inlets.dev/tutorial/automated-tcp-server/)
+* [Docs: Kubernetes TCP LoadBalancer](https://docs.inlets.dev/tutorial/kubernetes-tcp-loadbalancer/#co-existing-with-other-loadbalancers)

--- a/css/site.css
+++ b/css/site.css
@@ -75,4 +75,5 @@ ol, ul {
 /* Write your styles above this line. */
 
 
+
 @tailwind utilities;


### PR DESCRIPTION
Add post on auto-TLS verification step and improve 404 style

Auto TLS will now verify the CA before trusting it using the token itself to HMAC a nonce the client presents.

404 page restyled

Before/After

<img width="1470" height="757" alt="Screenshot 2026-07-13 at 17 22 17" src="https://github.com/user-attachments/assets/4d017674-74e0-4188-91d7-2569f2f1d5d4" />

<img width="1149" height="749" alt="Screenshot 2026-07-13 at 17 44 07" src="https://github.com/user-attachments/assets/f5def973-3293-4681-a34f-0ed2588dc22d" />
